### PR TITLE
Fix "type faster" misquote

### DIFF
--- a/TypeRacerStats/Core/typeracer_only.py
+++ b/TypeRacerStats/Core/typeracer_only.py
@@ -164,7 +164,7 @@ class TypeRacerOnly(commands.Cog):
                 title='FAQ: How do I type faster?',
                 color=discord.Color(0),
                 description=('_By: Izzy_\n\n'
-                             'Type the words faster in the right order.'))
+                             'type the words faster and in the right order'))
 
             await message.channel.send(content=f"<@{message.author.id}>",
                                        embed=embed)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/58539993/145689318-b7efc5af-f027-4769-b49b-2e2b0be24e95.png)
Change quote from 
> Type the words faster in the right order.

to 

> type the words faster and in the right order